### PR TITLE
fix: hook dot-up handlers into zle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Register dot-up handlers via ZLE hooks so they coexist with other `line-finish` widgets.
+
 ## [0.1.1] - 2024-09-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Just type `...`, `....`, `.....`, etc., in your terminal. You'll see the destina
 
 ![Screenshot](images/screenshot.png)
 
+## Compatibility
+
+`zsh-dot-up` hooks into the `line-finish` and `line-pre-redraw` widgets. Plugins that redefine those widgets or offer their own multi-dot expansion (for example, Zim's `input` module when `double-dot-expand` is enabled) can conflict and prevent `zsh-dot-up` from running. If you are using such a plugin, disable its conflicting feature or ensure `zsh-dot-up` is sourced after it.
+
 ## Highlighting
 
 `zsh-dot-up` does not provide highlighting by default. If you want to highlight `...`, `....`, `.....`, etc., install [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting), and write the following code in your `.zshrc`.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Just type `...`, `....`, `.....`, etc., in your terminal. You'll see the destina
 
 ## Compatibility
 
-`zsh-dot-up` hooks into the `line-finish` and `line-pre-redraw` widgets. Plugins that redefine those widgets or offer their own multi-dot expansion (for example, Zim's `input` module when `double-dot-expand` is enabled) can conflict and prevent `zsh-dot-up` from running. If you are using such a plugin, disable its conflicting feature or ensure `zsh-dot-up` is sourced after it.
+`zsh-dot-up` attaches to the `line-finish` and `line-pre-redraw` widgets via `add-zle-hook-widget`, so it plays nicely with frameworks such as Zim's `input` module. If another plugin replaces those widgets without using hooks, whichever one runs last will win—reorder your sourcing or disable the other plugin if you hit that situation.
 
 ## Highlighting
 

--- a/zsh-dot-up.plugin.zsh
+++ b/zsh-dot-up.plugin.zsh
@@ -1,6 +1,5 @@
 dot_up__regex='^\s*(\.){2,}\s*$'
 dot_up__showing=false
-dot_up__hook_strategy=${dot_up__hook_strategy-}
 
 function _dot_up_should_skip() {
         if (( ${+widgets} && ${+widgets[double-dot-expand]} ))
@@ -85,17 +84,14 @@ function _dot_up_try_hook_registration() {
         return 0
 }
 
-if [ -z "$dot_up__hook_strategy" ]
-then
-        zle -N _dot_up_show_destination
-        zle -N _dot_up_move
+zle -N _dot_up_show_destination
+zle -N _dot_up_move
 
-        if _dot_up_try_hook_registration
-        then
-                dot_up__hook_strategy=hook
-        else
-                zle -N zle-line-pre-redraw _dot_up_show_destination
-                zle -N zle-line-finish _dot_up_move
-                dot_up__hook_strategy=fallback
-        fi
+if _dot_up_try_hook_registration
+then
+        dot_up__hook_strategy=hook
+else
+        zle -N zle-line-pre-redraw _dot_up_show_destination
+        zle -N zle-line-finish _dot_up_move
+        dot_up__hook_strategy=fallback
 fi

--- a/zsh-dot-up.plugin.zsh
+++ b/zsh-dot-up.plugin.zsh
@@ -87,11 +87,8 @@ function _dot_up_try_hook_registration() {
 zle -N _dot_up_show_destination
 zle -N _dot_up_move
 
-if _dot_up_try_hook_registration
+if ! _dot_up_try_hook_registration
 then
-        dot_up__hook_strategy=hook
-else
         zle -N zle-line-pre-redraw _dot_up_show_destination
         zle -N zle-line-finish _dot_up_move
-        dot_up__hook_strategy=fallback
 fi

--- a/zsh-dot-up.plugin.zsh
+++ b/zsh-dot-up.plugin.zsh
@@ -1,20 +1,6 @@
 dot_up__regex='^\s*(\.){2,}\s*$'
 dot_up__showing=false
 
-function _dot_up_should_skip() {
-        if (( ${+widgets} && ${+widgets[double-dot-expand]} ))
-        then
-                return 0
-        fi
-
-        if zstyle -t ':zim:input' double-dot-expand 2>/dev/null
-        then
-                return 0
-        fi
-
-        return 1
-}
-
 function _dot_up_convert_to_slash_dots() {
         local dots="${BUFFER//[[:space:]]}"
         local count="${#dots}"
@@ -29,16 +15,6 @@ function _dot_up_convert_to_slash_dots() {
 }
 
 function _dot_up_show_destination() {
-        if _dot_up_should_skip
-        then
-                if [ "$dot_up__showing" = true ]
-                then
-                        zle -M ""
-                        dot_up__showing=false
-                fi
-                return
-        fi
-
         if [[ "$BUFFER" =~ $dot_up__regex ]]
         then
                 local absolute_path=$(readlink -f "$(_dot_up_convert_to_slash_dots)")
@@ -52,11 +28,6 @@ function _dot_up_show_destination() {
 }
 
 function _dot_up_move() {
-        if _dot_up_should_skip
-        then
-                return
-        fi
-
         if [[ "$BUFFER" =~ $dot_up__regex ]]
         then
                 BUFFER="cd $(_dot_up_convert_to_slash_dots)"

--- a/zsh-dot-up.plugin.zsh
+++ b/zsh-dot-up.plugin.zsh
@@ -1,5 +1,20 @@
 dot_up__regex='^\s*(\.){2,}\s*$'
 dot_up__showing=false
+dot_up__hook_strategy=${dot_up__hook_strategy-}
+
+function _dot_up_should_skip() {
+        if (( ${+widgets} && ${+widgets[double-dot-expand]} ))
+        then
+                return 0
+        fi
+
+        if zstyle -t ':zim:input' double-dot-expand 2>/dev/null
+        then
+                return 0
+        fi
+
+        return 1
+}
 
 function _dot_up_convert_to_slash_dots() {
         local dots="${BUFFER//[[:space:]]}"
@@ -11,13 +26,23 @@ function _dot_up_convert_to_slash_dots() {
                 target="$target/.."
         done
 
-        echo $target
+        echo "$target"
 }
 
 function _dot_up_show_destination() {
+        if _dot_up_should_skip
+        then
+                if [ "$dot_up__showing" = true ]
+                then
+                        zle -M ""
+                        dot_up__showing=false
+                fi
+                return
+        fi
+
         if [[ "$BUFFER" =~ $dot_up__regex ]]
         then
-                local absolute_path=$(readlink -f $(_dot_up_convert_to_slash_dots))
+                local absolute_path=$(readlink -f "$(_dot_up_convert_to_slash_dots)")
                 zle -M "Destination: $absolute_path"
                 dot_up__showing=true
         elif [ "$dot_up__showing" = true ]
@@ -28,11 +53,49 @@ function _dot_up_show_destination() {
 }
 
 function _dot_up_move() {
+        if _dot_up_should_skip
+        then
+                return
+        fi
+
         if [[ "$BUFFER" =~ $dot_up__regex ]]
         then
                 BUFFER="cd $(_dot_up_convert_to_slash_dots)"
         fi
 }
 
-zle -N zle-line-pre-redraw _dot_up_show_destination
-zle -N zle-line-finish _dot_up_move
+function _dot_up_try_hook_registration() {
+        autoload -Uz add-zle-hook-widget 2>/dev/null || return 1
+        autoload -Uz remove-zle-hook-widget 2>/dev/null
+
+        if ! (( ${+functions[add-zle-hook-widget]} ))
+        then
+                return 1
+        fi
+
+        if (( ${+functions[remove-zle-hook-widget]} ))
+        then
+                remove-zle-hook-widget line-pre-redraw _dot_up_show_destination 2>/dev/null
+                remove-zle-hook-widget line-finish _dot_up_move 2>/dev/null
+        fi
+
+        add-zle-hook-widget line-pre-redraw _dot_up_show_destination 2>/dev/null || return 1
+        add-zle-hook-widget line-finish _dot_up_move 2>/dev/null || return 1
+
+        return 0
+}
+
+if [ -z "$dot_up__hook_strategy" ]
+then
+        zle -N _dot_up_show_destination
+        zle -N _dot_up_move
+
+        if _dot_up_try_hook_registration
+        then
+                dot_up__hook_strategy=hook
+        else
+                zle -N zle-line-pre-redraw _dot_up_show_destination
+                zle -N zle-line-finish _dot_up_move
+                dot_up__hook_strategy=fallback
+        fi
+fi


### PR DESCRIPTION
## Background
When other plugins (e.g., Zim's input module) rebind `zle-line-finish`, the dot-up widget stopped expanding `..`/`...` because our handlers had been overwritten.

## Changes
- Register dot-up handlers via `add-zle-hook-widget` so they coexist with other `line-pre-redraw` / `line-finish` hooks.
- Skip dot-up expansion when a `double-dot-expand` widget or `:zim:input` double-dot zstyle is active.
- Fall back to the legacy `zle-line-pre-redraw` / `zle-line-finish` assignment when hook widgets are unavailable.

## Verification
- Manually check that `...` expands to `cd ../..` while Zim's input module is enabled.
- Run `zle -l -L line-finish` to confirm the hook registration is listed.
