### PR TITLE
chore: release 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release.
 
 [Unreleased]: https://github.com/toku-sa-n/zsh-dot-up/compare/v0.1.2...HEAD
-[0.1.2]: https://github.com/toku-sa-n/zsh-dot-up/compare/v0.1.1...v0.1.2
-[0.1.1]: https://github.com/toku-sa-n/zsh-dot-up/releases/tag/v0.1.0...v0.1.1
+[0.1.2]: https://github.com/toku-sa-n/zsh-dot-up/releases/tag/v0.1.2
+[0.1.1]: https://github.com/toku-sa-n/zsh-dot-up/releases/tag/v0.1.1
 [0.1.0]: https://github.com/toku-sa-n/zsh-dot-up/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2025-10-12
+
 ### Fixed
 
 - Register dot-up handlers via ZLE hooks so they coexist with other `line-finish` widgets.
@@ -23,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/toku-sa-n/zsh-dot-up/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/toku-sa-n/zsh-dot-up/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/toku-sa-n/zsh-dot-up/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/toku-sa-n/zsh-dot-up/releases/tag/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/toku-sa-n/zsh-dot-up/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary
- promote the ZLE hook integration as v0.1.2
- document the release in the changelog

## Testing
- not run
